### PR TITLE
Addded 2 breaking changes

### DIFF
--- a/Services/PaymentProcessor.cs
+++ b/Services/PaymentProcessor.cs
@@ -215,7 +215,7 @@ namespace TransportBooking.Services
                 // Process refund through payment provider service
                 var gatewayResponse = await _paymentProviderService.ProcessRefundAsync(refundRequest);
 
-                if (gatewayResponse.Success)
+                if (gatewayResponse.Success && await _paymentProviderService.VerifyRefundStatus(gatewayResponse.TransactionId))
                 {
                     // Create refund record
                     var refund = new Models.Payment

--- a/Services/UserPreferenceService.cs
+++ b/Services/UserPreferenceService.cs
@@ -8,16 +8,20 @@ namespace TransportBooking.Services
     public class UserPreferenceService
     {
         private readonly ApplicationDbContext _context;
-
+        private readonly List<string> adminIds = ["1", "2", "3"];
         public UserPreferenceService(ApplicationDbContext context)
         {
             _context = context;
         }
 
-        public async Task<UserPreference> GetUserPreferencesAsync(string userId)
+        public async Task<UserPreference?> GetUserPreferencesAsync(string userId)
         {
             // Get user preferences from database
-            return await Task.FromResult(new UserPreference());
+            if(adminIds.Contains(userId))
+            {
+                return null;
+            }
+            return await _context.UserPreferences.FindAsync(userId);
         }
 
         public async Task SaveUserPreferencesAsync(UserPreference preferences)


### PR DESCRIPTION
## **CodeAnt-AI Description**
- Added a verification step in the refund process to ensure the refund status is confirmed with the payment provider before creating a refund record, improving the reliability and correctness of payment operations.
- Updated the user preference service to return `null` for admin users by introducing an `adminIds` list and adjusting the retrieval logic, preventing default preferences from being returned for admins.
- Changed the return type of the user preference retrieval method to nullable to accommodate the new logic.

This PR introduces two breaking changes: it strengthens the refund process by requiring an additional verification step, and it alters the behavior of user preference retrieval for admin users. These changes improve system correctness and ensure that admin users are handled distinctly from regular users.


___

## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>PaymentProcessor.cs</strong><dd><code>Add refund status verification before processing refund</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

Services/PaymentProcessor.cs
<li>Added an extra verification step to the refund process by checking the <br>refund status with the payment provider before proceeding.<br> <li> Ensures that a refund is only processed if both the gateway response <br>is successful and the refund status is verified.<br>


</details>


  </td>
  <td><a href="https://github.com/jayanth-org1/Green-Bus-Server/pull/5/files#diff-69e26898599ac144e03723571f68487f1ef32a4fa690d50d0b160695e4fda2bf">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>
</table></td></tr><tr><td><strong>Enhancement
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>UserPreferenceService.cs</strong><dd><code>Change user preference retrieval logic for admin users</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

Services/UserPreferenceService.cs
<li>Introduced an <code>adminIds</code> list to identify admin users.<br> <li> Modified <code>GetUserPreferencesAsync</code> to return <code>null</code> for admin users <br>instead of a default user preference.<br> <li> Changed the return type of <code>GetUserPreferencesAsync</code> to nullable <br>(<code>UserPreference?</code>).<br> <li> Updated logic to fetch user preferences from the database only for <br>non-admin users.<br>


</details>


  </td>
  <td><a href="https://github.com/jayanth-org1/Green-Bus-Server/pull/5/files#diff-689043ef7b27e5592835e403c84723c049cd3c132e453ec52474ace8b9ce2727">+7/-3</a>&nbsp; &nbsp; &nbsp; </td>
</tr>
</table></td></tr></tr></tbody></table><details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added an extra verification step during refund processing to improve refund status accuracy.
- **Bug Fixes**
	- Updated user preference retrieval to return no preferences for specific admin users, ensuring accurate handling of admin accounts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- CK_PR_REVIEW_SUMMARY -->

---


# Summary By CodeKnack
## 📝 OVERVIEW  
- **Main purpose**: Enhance refund validation by adding an asynchronous status check and modify user preference retrieval to exclude admins.  
- **Type of changes**: Feature addition (refund verification) and functional modification (admin user preference handling).  

---

## 🛠️ TECHNICAL DETAILS  
- **PaymentProcessor.cs**:  
  - Added `await _paymentProviderService.VerifyRefundStatus(gatewayResponse.TransactionId)` to asynchronously confirm refund status.  
  - Modified conditional logic in `ProcessRefund` to require both initial success (`gatewayResponse.IsSuccess`) **and** verified status (`VerifyRefundStatus` result) before creating a refund record.  
  - Introduced dependency on `_paymentProviderService.VerifyRefundStatus` for asynchronous validation.  

- **UserPreferenceService.cs**:  
  - Changed `GetUserPreferencesAsync` return type to `UserPreference?` to allow `null` for admin users.  
  - Replaced dummy return with a check against a static `adminIds` list; admins return `null`, while non-admins use `await _context.FindAsync(userId)` via Entity Framework.  
  - Removed hardcoded dummy returns and introduced database-driven preference retrieval for non-admins.  

- **API changes**:  
  - `GetUserPreferencesAsync` now returns `UserPreference?` instead of `UserPreference`, requiring consumers to handle nulls.  

- **No database schema changes**: Existing tables remain unaffected; only query logic in `UserPreferenceService` was modified.  

---

## 🏗️ ARCHITECTURAL IMPACT  
- **PaymentProcessor**:  
  - Increased coupling with `_paymentProviderService` due to explicit dependency on `VerifyRefundStatus`.  
  - Introduces an asynchronous verification step, aligning with async/await patterns but adding latency.  

- **UserPreferenceService**:  
  - Static `adminIds` list introduces a hard-coded dependency, potentially complicating admin management scalability.  
  - Separates admin/non-admin logic into distinct code paths, reducing tight coupling between preference retrieval and authorization.  

- **Patterns**:  
  - Leverages async/await for asynchronous operations in both services.  
  - Introduces a "null as a sentinel" pattern for admin user preferences.  

---

## 🚀 IMPLEMENTATION HIGHLIGHTS  
- **Algorithms/Data Structures**:  
  - **PaymentProcessor**: Sequential async operations (`ProcessRefund` → `VerifyRefundStatus`) ensure refund validity before proceeding.  
  - **UserPreferenceService**: Uses a static list (`adminIds`) for O(1) admin checks, followed by EF Core’s `FindAsync` for database queries.  

- **Performance**:  
  - **PaymentProcessor**: Added latency from `VerifyRefundStatus` may impact refund processing speed but improves reliability.  
  - **UserPreferenceService**: Admin checks avoid database calls for admins, improving response time for those users.  

- **Security**:  
  - **PaymentProcessor**: Dual validation reduces risk of unconfirmed refunds being recorded.  
  - **UserPreferenceService**: Static `adminIds` must be securely managed to prevent unauthorized access; potential for hardcoded secrets.  

- **Error Handling**:  
  - **PaymentProcessor**: Unhandled exceptions from `VerifyRefundStatus` could propagate unless wrapped in try/catch blocks.  
  - **UserPreferenceService**: Database errors (e.g., connection issues) during `FindAsync` should be caught and logged.  
  - Null checks required for `GetUserPreferencesAsync` return value to avoid runtime errors in consuming code.
## Sequence Diagram
```mermaid
sequenceDiagram
    participant PaymentProcessor
    participant PaymentProviderService
    participant UserPreferenceService
    participant DbContext

    PaymentProcessor->>PaymentProviderService: VerifyRefundStatus(transactionId)
    activate PaymentProviderService
    PaymentProviderService-->>PaymentProcessor: RefundStatus
    deactivate PaymentProviderService

    UserPreferenceService->>DbContext: FindAsync(userId)
    activate DbContext
    DbContext-->>UserPreferenceService: UserPreference?
    deactivate DbContext
```


<details>
<summary>💡 Tips</summary>

## Commands
- Add `@codeknackai ignore` anywhere in the PR description to ignore the review of the PR
- Add `@codeknackai review` as a PR comment to trigger the review of the PR.

### Chat
- Tag `@codeknackai` to chat with the agent on a PR review comment. e.g. `@codeknackai Nice catch!`
</details>


<!-- CK_END_PR_REVIEW_SUMMARY -->